### PR TITLE
Fixed an issue with Numba's cache. Signed-off-by: griffin.milsap@gmai…

### DIFF
--- a/python3-data-science/Dockerfile
+++ b/python3-data-science/Dockerfile
@@ -85,3 +85,6 @@ RUN export NODE_OPTIONS=--max-old-space-size=4096 && \
 # Import matplotlib the first time to build the font cache.
 ENV XDG_CACHE_HOME /opt/matplotlib/.cache/
 RUN MPLBACKEND=Agg python -c "import matplotlib.pyplot"
+
+# Give Numba a writeable location for intermediate files
+ENV NUMBA_CACHE_DIR /tmp


### PR DESCRIPTION
By default, Numba will optimize `@jit` decorated functions and place the output in the __pycache__ directory within the same directory that the file exists. When Numba optimizes files installed into a system directory, the user running the code is unable to write to the installation directory, and there's no fallback location, resulting in awful error messages.

This pull request uses an environment variable to direct Numba to a new writeable location for its intermediate files.